### PR TITLE
ENH: Updated streamcat function and classes to match with new API des…

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,20 @@
 History
 =======
 
+New Features
+~~~~~~~~~~~~
+- Update StreamCat features to comply with the new StreamCat API.
+  Changed the base URL to  epa.api.gov/StreamCat/streams for StreamCat 
+  and epa.api.gov/StreamCat/lakes for lakecat.
+- Changed all valid attributes in StreamCat object to work with new /metrics
+  route.
+- Converted async-retriever to get json instead of text for streamcat function
+  new api always returns a json object called ``items`` so we grab that and create
+  a dataframe using the from_records constructor in pandas.
+
+By Travis Hudson (https://github.com/TravisH18/pynhd) 12/30/2024
+
+
 0.18.1 (2024-10-08)
 -------------------
 

--- a/tests/test_pynhd.py
+++ b/tests/test_pynhd.py
@@ -35,9 +35,9 @@ def trib():
 
 def test_streamcat():
     nhd_area = pynhd.streamcat("fert", comids=13212248)
-    assert_close(nhd_area["FERTWS"].item(), 14.358)
+    assert_close(nhd_area["fertws"].item(), 14.358)
     nhd_area = pynhd.streamcat("inorgnwetdep2008", comids=23783629, lakes_only=True)
-    assert_close(nhd_area["INORGNWETDEP2008WS"].item(), 1.7746)
+    assert_close(nhd_area["inorgnwetdep2008ws"].item(), 1.7746)
 
 
 @pytest.mark.xfail(reason="EPA's HMS is unstable.")


### PR DESCRIPTION
…ign. Changed base_url, validation variables and async retreiver to use JSON object types like the new responses do.
- Update StreamCat features to comply with the new StreamCat API.
  Changed the base URL to  epa.api.gov/StreamCat/streams for StreamCat 
  and epa.api.gov/StreamCat/lakes for lakecat.
- Changed all valid attributes in StreamCat object to work with new /metrics
  route.
- Converted async-retriever to get json instead of text for streamcat function
  new api always returns a json object called ``items`` so we grab that and create
  a dataframe using the from_records constructor in pandas.

<!-- Feel free to remove check-list items aren't relevant to your changes -->

 - [x] Tests added and `nox` passes.
 - [x] Changes and the contributor name are documented in `HISTORY.rst`.
